### PR TITLE
Fix splitter

### DIFF
--- a/src/tink/io/StreamParser.hx
+++ b/src/tink/io/StreamParser.hx
@@ -41,8 +41,7 @@ class Splitter implements StreamParser<Bytes> {
   function writeBytes(bytes:Bytes, start:Int, length:Int) {
     
     if (!atEnd) {
-      length -= delim.length;
-      if (length < 0) length = 0;
+      if (length < delim.length) length = 0;
     }
     
     if (length > 0) {


### PR DESCRIPTION
Don't deduct the length like that. If the incoming bytes just end after the delimiter, it will never emit a result.
