### PR TITLE
Fix OutputSink.end

### DIFF
--- a/src/tink/io/std/OutputSink.hx
+++ b/src/tink/io/std/OutputSink.hx
@@ -62,7 +62,7 @@ class OutputSink extends tink.io.Sink.SinkBase<Error, Noise> {
     }));
     
     if (options.end)
-      ret.handle(function (end) try target.close() catch (e:Dynamic) {});    
+      ret.handle(function (end) try{ target.flush(); target.close();} catch (e:Dynamic) {});    
     
     return ret.map(function (c) return c.toResult(Noise, rest));    
   }


### PR DESCRIPTION
Not possible to do concurrent writes to the same file without flushing the bytes to the underlying stream.