### PR TITLE
Adjust to haxe 5 enum resolution changes

### DIFF
--- a/src/tink/io/Source.hx
+++ b/src/tink/io/Source.hx
@@ -102,7 +102,7 @@ abstract Source<E>(SourceObject<E>) from SourceObject<E> to SourceObject<E> to S
     return this;
   
   static public function concatAll<E>(s:Stream<Chunk, E>)
-    return s.reduce(Chunk.EMPTY, function (res:Chunk, cur:Chunk) return Progress(res & cur));
+    return s.reduce(Chunk.EMPTY, function (res:Chunk, cur:Chunk) return ReductionStep.Progress(res & cur));
 
   public function pipeTo<EOut, Result>(target:SinkYielding<EOut, Result>, ?options):Future<PipeResult<E, EOut, Result>> 
     return target.consume(this, options);


### PR DESCRIPTION
In haxe 5, enum constructors no longer take priority over class names, so this gives:
```
Abstract<tink.core.Progress> cannot be called
```
See haxe issues:
https://github.com/HaxeFoundation/haxe/issues/9197
https://github.com/HaxeFoundation/haxe/pull/11168