### PR TITLE
Support JS ReadableStream

### DIFF
--- a/hxformat.json
+++ b/hxformat.json
@@ -1,0 +1,46 @@
+{
+	"indentation": {
+		"character": "  ",
+		"tabWidth": 2,
+		"trailingWhitespace": false
+	},
+	"sameLine": {
+		"functionBody": "keep",
+		"anonFunctionBody": "keep",
+		"ifBody": "keep",
+		"elseBody": "keep",
+		"forBody": "keep",
+		"whileBody": "keep",
+		"doWhileBody": "keep",
+		"tryBody": "keep",
+		"catchBody": "keep",
+		"caseBody": "keep",
+		"expressionCase": "keep",
+		"returnBody": "keep",
+		"returnBodySingleLine": "keep"
+	},
+	"wrapping": {
+		"maxLineLength": 160,
+		"callParameter": { "defaultWrap": "keep" },
+		"arrayWrap": { "defaultWrap": "keep" },
+		"objectLiteral": { "defaultWrap": "keep" },
+		"methodChain": { "defaultWrap": "keep" },
+		"opBoolChain": { "defaultWrap": "keep" },
+		"opAddSubChain": { "defaultWrap": "keep" }
+	},
+	"emptyLines": {
+		"finalNewline": false,
+		"maxAnywhereInFile": 2
+	},
+	"whitespace": {
+		"ifPolicy": "after",
+		"forPolicy": "none",
+		"whilePolicy": "none",
+		"catchPolicy": "after",
+		"doPolicy": "after",
+		"objectFieldColonPolicy": "after",
+		"colonPolicy": "none",
+		"arrowFunctionsPolicy": "around",
+		"binopPolicy": "around"
+	}
+}

--- a/src/tink/io/Source.hx
+++ b/src/tink/io/Source.hx
@@ -69,6 +69,9 @@ abstract Source<E>(SourceObject<E>) from SourceObject<E> to SourceObject<E> to S
     var chunkSize = options == null || options.chunkSize == null ? 1 << 24 : options.chunkSize;
     return tink.io.js.BlobSource.wrap(name, blob, chunkSize);
   }
+
+  @:noUsing static public inline function ofReadableStream(name:String, stream:tink.io.js.ReadableStream):RealSource
+    return tink.io.js.ReadableStreamSource.wrap(name, stream);
   #end
   
   #if cs

--- a/src/tink/io/Source.hx
+++ b/src/tink/io/Source.hx
@@ -70,8 +70,11 @@ abstract Source<E>(SourceObject<E>) from SourceObject<E> to SourceObject<E> to S
     return tink.io.js.BlobSource.wrap(name, blob, chunkSize);
   }
 
+  #if !nodejs
   @:noUsing static public inline function ofReadableStream(name:String, stream:tink.io.js.ReadableStream):RealSource
     return tink.io.js.ReadableStreamSource.wrap(name, stream);
+  #end
+  
   #end
   
   #if cs

--- a/src/tink/io/js/ReadableStream.hx
+++ b/src/tink/io/js/ReadableStream.hx
@@ -1,0 +1,7 @@
+package tink.io.js;
+
+// This type should be defined in js.lib or somewhere else
+@:native('ReadableStream')
+extern class ReadableStream {
+  function getReader():ReadableStreamSource.ReadableStreamReader;
+}

--- a/src/tink/io/js/ReadableStreamSource.hx
+++ b/src/tink/io/js/ReadableStreamSource.hx
@@ -1,0 +1,41 @@
+package tink.io.js;
+
+import js.lib.Promise as JsPromise;
+import js.lib.Uint8Array;
+import tink.streams.Stream;
+
+using tink.CoreApi;
+
+typedef ReadableStreamReader = {
+  function read():JsPromise<ReadableStreamReadResult>;
+}
+
+typedef ReadableStreamReadResult = {
+  final done:Bool;
+  final value:Null<Uint8Array>;
+}
+
+class ReadableStreamSource extends Generator<Chunk, Error> {
+  var name:String;
+
+  function new(name:String, reader:ReadableStreamReader) {
+    this.name = name;
+
+    super(Future.irreversible(function(cb) {
+      reader.read().then(
+        function(result) {
+          if (result.done || result.value == null)
+            cb(End);
+          else {
+            final chunk:Chunk = result.value;
+            cb(Link(chunk, new ReadableStreamSource(name, reader)));
+          }
+        },
+        function(e) cb(Fail(Error.withData('Error reading from $name', e)))
+      );
+    }));
+  }
+
+  static public inline function wrap(name:String, stream:ReadableStream)
+    return new ReadableStreamSource(name, stream.getReader());
+}

--- a/src/tink/io/js/ReadableStreamSource.hx
+++ b/src/tink/io/js/ReadableStreamSource.hx
@@ -27,8 +27,7 @@ class ReadableStreamSource extends Generator<Chunk, Error> {
           if (result.done || result.value == null)
             cb(End);
           else {
-            final chunk:Chunk = result.value;
-            cb(Link(chunk, new ReadableStreamSource(name, reader)));
+            cb(Link((result.value : Chunk), new ReadableStreamSource(name, reader)));
           }
         },
         function(e) cb(Fail(Error.withData('Error reading from $name', e)))

--- a/tests/JsTest.hx
+++ b/tests/JsTest.hx
@@ -39,4 +39,21 @@ class JsTest {
 			.handle(asserts.handle);
 		return asserts;
 	}
+
+	public function readableStream() {
+		final stream:tink.io.js.ReadableStream = js.Syntax.code('new ReadableStream({
+			start(controller) {
+				controller.enqueue(new TextEncoder().encode("ti"));
+				controller.enqueue(new TextEncoder().encode("nk"));
+				controller.close();
+			}
+		})');
+		Source.ofReadableStream('ReadableStream', stream).all()
+			.next(function(chunk) {
+				asserts.assert(chunk.toString() == 'tink');
+				return Noise;
+			})
+			.handle(asserts.handle);
+		return asserts;
+	}
 }


### PR DESCRIPTION
The `ReadableStream` extern is miserable, but I don't know what we can do besides addressing the js externs in stdlib.